### PR TITLE
Change the check for if collection is received to ignore the files se…

### DIFF
--- a/src/status_checker_lambda/status_checker.py
+++ b/src/status_checker_lambda/status_checker.py
@@ -566,7 +566,6 @@ def is_collection_received(
     is_received = (
         collection_status in [EXPORTED_STATUS_VALUE, SENT_STATUS_VALUE]
         and collection_files_received_count
-        == collection_files_sent_count
         == collection_files_exported_count
     )
 

--- a/src/status_checker_lambda/status_checker.py
+++ b/src/status_checker_lambda/status_checker.py
@@ -565,8 +565,7 @@ def is_collection_received(
 
     is_received = (
         collection_status in [EXPORTED_STATUS_VALUE, SENT_STATUS_VALUE]
-        and collection_files_received_count
-        == collection_files_exported_count
+        and collection_files_received_count == collection_files_exported_count
     )
 
     logger.info(

--- a/tests/test_status_checker.py
+++ b/tests/test_status_checker.py
@@ -1704,7 +1704,7 @@ class TestReplayer(unittest.TestCase):
         self.assertFalse(actual)
 
     @mock.patch("status_checker_lambda.status_checker.logger")
-    def test_is_collection_received_returns_false_when_more_files_sent(
+    def test_is_collection_received_returns_true_when_more_files_sent(
         self,
         mock_logger,
     ):
@@ -1721,7 +1721,7 @@ class TestReplayer(unittest.TestCase):
             TEST_FILE_NAME,
         )
 
-        self.assertFalse(actual)
+        self.assertTrue(actual)
 
     @mock.patch("status_checker_lambda.status_checker.logger")
     def test_is_collection_received_returns_false_when_more_files_received(
@@ -1774,26 +1774,6 @@ class TestReplayer(unittest.TestCase):
             "FilesExported": {"N": 1},
             "FilesReceived": {"N": 1},
             "FilesSent": {"N": 1},
-        }
-
-        actual = status_checker.is_collection_received(
-            event,
-            TEST_FILE_NAME,
-        )
-
-        self.assertFalse(actual)
-
-    @mock.patch("status_checker_lambda.status_checker.logger")
-    @mock.patch("status_checker_lambda.status_checker.logger")
-    def test_update_status_for_collection_sends_right_message(
-        self,
-        mock_logger,
-    ):
-        event = {
-            "CollectionStatus": {"S": EXPORTED_STATUS},
-            "CollectionName": {"S": COLLECTION_1},
-            "FilesReceived": 1,
-            "FilesSent": 1,
         }
 
         actual = status_checker.is_collection_received(


### PR DESCRIPTION
Change the check for if collection is received to ignore the files sent count as it might be behind because of snapshot sender process but a file can't be received without being sent, this will fix the timing edge case we have seen recently stopping a success file being sent