### PR TITLE
Delete metrics

### DIFF
--- a/src/status_checker_lambda/status_checker.py
+++ b/src/status_checker_lambda/status_checker.py
@@ -206,7 +206,10 @@ def push_metrics(
     )
 
     prometheus_client.pushadd_to_gateway(
-        gateway=f"{host_name}:{port}", job=job_name, grouping_key=correlation_id, registry=registry
+        gateway=f"{host_name}:{port}",
+        job=job_name,
+        grouping_key=correlation_id,
+        registry=registry,
     )
 
     logger.info(

--- a/src/status_checker_lambda/status_checker.py
+++ b/src/status_checker_lambda/status_checker.py
@@ -5,7 +5,6 @@ import os
 import sys
 import socket
 import json
-import uuid
 import prometheus_client
 
 CORRELATION_ID_FIELD_NAME = "correlation_id"
@@ -41,13 +40,13 @@ required_message_keys = [
 args = None
 logger = None
 
+METRICS_JOB_NAME = "snapshot_sender_status_checker"
 METRICS_REGISTRY = prometheus_client.CollectorRegistry()
 METRIC_LABEL_NAMES = [
     "correlation_id",
     "collection_name",
     "export_date",
     "snapshot_type",
-    "file_name",
 ]
 MESSAGE_PROCESSING_TIME = prometheus_client.Summary(
     "snapshot_sender_status_checker_message_processing_time",
@@ -177,7 +176,8 @@ def push_metrics(
     registry,
     host_name,
     port,
-    unique_request_id,
+    job_name,
+    correlation_id,
 ):
     """Pushes metrics to the push-gateway.
 
@@ -185,33 +185,70 @@ def push_metrics(
         registry (object) the metrics registry to use
         host_name (string) the host name for the push gateway
         port (string) the post number for the push gateway
-        snapshot_type (string): full or incremental
-        collection_name (string): the collection name that has been received
-        file_name: (string) file name for logging purposes
+        job_name (string): a name for the metrics job
         correlation_id: (string) the correlation id of this run
-        export_date (string): the date of the export
-        unique_request_id (string): a unique id for this request
 
     """
+    url = f"{host_name}:{port}"
+
     if not host_name:
         logger.info(
             f'Not pushing metrics to the push gateway due to no host name set", "host_name": "{host_name}", '
-            + f'"unique_request_id": "{unique_request_id}", "port": "{port}"'
+            + f'"job_name": "{job_name}", "correlation_id": "{correlation_id}", "port": "{port}", "url": "{url}'
         )
         return
 
     logger.info(
         f'Pushing metrics to the push gateway", "host_name": "{host_name}", '
-        + f'"unique_request_id": "{unique_request_id}", "port": "{port}"'
+        + f'"job_name": "{job_name}", "correlation_id": "{correlation_id}", "port": "{port}", "url": "{url}'
     )
 
-    prometheus_client.push_to_gateway(
-        f"{host_name}:{port}", job=f"{unique_request_id}", registry=registry
+    prometheus_client.pushadd_to_gateway(
+        gateway=f"{host_name}:{port}", job=job_name, grouping_key=correlation_id, registry=registry
     )
 
     logger.info(
         f'Pushed metrics to the push gateway", "host_name": "{host_name}", '
-        + f'"unique_request_id": "{unique_request_id}", "port": "{port}"'
+        + f'"job_name": "{job_name}", "correlation_id": "{correlation_id}", "port": "{port}", "url": "{url}'
+    )
+
+
+def delete_metrics(
+    host_name,
+    port,
+    job_name,
+    correlation_id,
+):
+    """Deletes metrics from the push-gateway.
+
+    Arguments:
+        host_name (string) the host name for the push gateway
+        port (string) the post number for the push gateway
+        job_name (string): a name for the metrics job
+        correlation_id: (string) the correlation id of this run
+
+    """
+    url = f"{host_name}:{port}"
+
+    if not host_name:
+        logger.info(
+            f'Not deleting metrics to the push gateway due to no host name set", "host_name": "{host_name}", '
+            + f'"job_name": "{job_name}", "correlation_id": "{correlation_id}", "port": "{port}", "url": "{url}'
+        )
+        return
+
+    logger.info(
+        f'Deleting metrics from the push gateway", "host_name": "{host_name}", '
+        + f'"job_name": "{job_name}", "correlation_id": "{correlation_id}", "port": "{port}", "url": "{url}'
+    )
+
+    prometheus_client.delete_from_gateway(
+        gateway=f"{host_name}:{port}", job=job_name, grouping_key=correlation_id
+    )
+
+    logger.info(
+        f'Deleted metrics from the push gateway", "host_name": "{host_name}", '
+        + f'"job_name": "{job_name}", "correlation_id": "{correlation_id}", "port": "{port}", "url": "{url}'
     )
 
 
@@ -500,38 +537,40 @@ def update_files_received_for_collection(
     return response[ATTRIBUTES_FIELD_NAME]
 
 
-def add_label_values_to_metric(
-    metric,
+def increment_counter(
+    counter,
     correlation_id,
     collection_name,
     export_date,
     snapshot_type,
-    file_name,
+    value=1,
 ):
-    """Adds all the relevant labels to the metrics.
+    """Increments the given counter by the given amount.
 
     Arguments:
-        metric (object): The metric to add labels to (must have been initialised with the labels)
+        counter (object): The counter to increment (must have been initialised with the labels)
         correlation_id (string): String value of CorrelationId column
         collection_name (string): String value of CollectionName column
         export_date (string): The date of the export
         snapshot_type (string): Will be full or incremental
-        file_name (string): The file name
+        value (int): Increment value (default is 1)
     """
     logger.info(
-        f'Adding label values to metric", "metric": "{metric}", "snapshot_type": "{snapshot_type}", "correlation_id": '
-        + f'"{correlation_id}", "collection_name": "{collection_name}",  "export_date": "{export_date}", "file_name": "{file_name}'
+        f'Incrementing counter", "counter": "{counter}", "snapshot_type": "{snapshot_type}", "correlation_id": '
+        + f'"{correlation_id}", "value": "{value}", "collection_name": "{collection_name}",  "export_date": "{export_date}'
     )
 
-    metric.labels(
+    counter.labels(
         correlation_id=correlation_id,
         collection_name=collection_name,
         export_date=export_date,
         snapshot_type=snapshot_type,
-        file_name=file_name,
-    )
+    ).inc(value)
 
-    return metric
+    logger.info(
+        f'Incremented counter", "counter": "{counter}", "snapshot_type": "{snapshot_type}", "correlation_id": '
+        + f'"{correlation_id}", "value": "{value}", "collection_name": "{collection_name}",  "export_date": "{export_date}'
+    )
 
 
 def update_status_for_collection(
@@ -697,15 +736,6 @@ def is_collection_received(
     )
 
     if is_received:
-        counter_with_labels = add_label_values_to_metric(
-            counter,
-            correlation_id,
-            collection_name,
-            export_date,
-            snapshot_type,
-            file_name,
-        )
-
         logger.info(
             f'Incrementing received collections counter", "is_received": "{is_received}", "collection_status": '
             + f'"{collection_status}", "collection_files_received_count": "{collection_files_received_count}", '
@@ -715,7 +745,13 @@ def is_collection_received(
             + f'"file_name": "{file_name}'
         )
 
-        counter_with_labels.inc()
+        increment_counter(
+            counter,
+            correlation_id,
+            collection_name,
+            export_date,
+            snapshot_type,
+        )
 
     return is_received
 
@@ -761,15 +797,6 @@ def is_collection_success(
     )
 
     if is_success:
-        counter_with_labels = add_label_values_to_metric(
-            counter,
-            correlation_id,
-            collection_name,
-            export_date,
-            snapshot_type,
-            file_name,
-        )
-
         logger.info(
             f'Incrementing successful collections counter", "is_success": "{is_success}", "collection_status": '
             + f'"collection_status": "{collection_status}", '
@@ -778,7 +805,13 @@ def is_collection_success(
             + f'"file_name": "{file_name}'
         )
 
-        counter_with_labels.inc()
+        increment_counter(
+            counter,
+            correlation_id,
+            collection_name,
+            export_date,
+            snapshot_type,
+        )
 
     return is_success
 
@@ -838,7 +871,7 @@ def process_success_file_message(
     sns_topic_arn,
     file_name,
 ):
-    """Processes an individual success files message.
+    """Processes an individual success files message and returns true if all collections successful.
 
     Arguments:
         ddb_table (string): The ddb table name
@@ -906,12 +939,15 @@ def process_success_file_message(
                 correlation_id,
                 file_name,
             )
+
             send_sns_message(
                 sns_client,
                 sns_payload,
                 sns_topic_arn,
                 file_name,
             )
+
+            return True
         else:
             logger.info(
                 f'All collections have not been successful so no further processing", "file_name": "{file_name}", '
@@ -924,6 +960,8 @@ def process_success_file_message(
             + f'"correlation_id": "{correlation_id}", "snapshot_type": "{snapshot_type}", '
             + f'"collection_name": "{collection_name}", "file_name": "{file_name}'
         )
+
+    return False
 
 
 def process_normal_file_message(
@@ -1079,6 +1117,8 @@ def process_message(
         export_date (string): The export date
         file_name (string): For logging purposes
     """
+    result = False
+
     dumped_message = get_escaped_json_string(message)
     logger.info(
         f'Processing new message", "message": "{dumped_message}", "file_name": "{file_name}", '
@@ -1105,7 +1145,7 @@ def process_message(
     )
 
     if is_success_file:
-        process_success_file_message(
+        result = process_success_file_message(
             ddb_table,
             dynamodb_client,
             sns_client,
@@ -1133,6 +1173,8 @@ def process_message(
             file_name,
         )
 
+    return result
+
 
 def handle_message(
     message,
@@ -1142,6 +1184,8 @@ def handle_message(
     ddb_table,
     sns_topic_arn,
     sqs_queue_url,
+    pushgateway_host,
+    pushgateway_port,
 ):
     """Handles an individual message.
 
@@ -1153,6 +1197,8 @@ def handle_message(
         ddb_table (string): The ddb table name
         sns_topic_arn (string): The arn of the SNS topic to send to
         sqs_queue_url (string): The url of the SQS queue to send to
+        pushgateway_host (string): The host name of the push gateway
+        pushgateway_port (string): The port of the push gateway
     """
     dumped_message = get_escaped_json_string(message)
     logger.info(f'Handling new message", "message": "{dumped_message}"')
@@ -1171,20 +1217,39 @@ def handle_message(
         else "NOT_SET"
     )
 
-    process_message(
-        message,
-        dynamodb_client,
-        sqs_client,
-        sns_client,
-        ddb_table,
-        sns_topic_arn,
-        sqs_queue_url,
-        correlation_id,
-        collection_name,
-        snapshot_type,
-        export_date,
-        file_name,
-    )
+    all_collections_successful = False
+
+    try:
+        all_collections_successful = process_message(
+            message,
+            dynamodb_client,
+            sqs_client,
+            sns_client,
+            ddb_table,
+            sns_topic_arn,
+            sqs_queue_url,
+            correlation_id,
+            collection_name,
+            snapshot_type,
+            export_date,
+            file_name,
+        )
+    finally:
+        push_metrics(
+            METRICS_REGISTRY,
+            pushgateway_host,
+            pushgateway_port,
+            METRICS_JOB_NAME,
+            correlation_id,
+        )
+
+        if all_collections_successful:
+            delete_metrics(
+                pushgateway_host,
+                pushgateway_port,
+                METRICS_JOB_NAME,
+                correlation_id,
+            )
 
 
 def handler(event, context):
@@ -1197,44 +1262,23 @@ def handler(event, context):
     dumped_event = get_escaped_json_string(event)
     logger.info(f'Processing new event", "event": "{dumped_event}"')
 
-    try:
-        dynamodb_client = get_client("dynamodb")
-        sqs_client = get_client("sqs")
-        sns_client = get_client("sns")
+    dynamodb_client = get_client("dynamodb")
+    sqs_client = get_client("sqs")
+    sns_client = get_client("sns")
 
-        messages = extract_messages(event)
+    messages = extract_messages(event)
 
-        for message in messages:
-            handle_message(
-                message,
-                dynamodb_client,
-                sqs_client,
-                sns_client,
-                args.dynamo_db_export_status_table_name,
-                args.monitoring_sns_topic_arn,
-                args.export_state_sqs_queue_url,
-            )
-    finally:
-        unique_id = None
-
-        if "awsRequestId" in event and event["awsRequestId"]:
-            unique_id = event["awsRequestId"]
-            logger.warn(
-                'Using awsRequestId from event for metrics group", '
-                + f'"host_name": "{args.pushgateway_hostname}", "unique_request_id": "{unique_id}", "port": "{args.pushgateway_port}"'
-            )
-        else:
-            unique_id = uuid.uuid4()
-            logger.info(
-                'No awsRequestId or awsRequestId blank in event so could not use it for metrics group", '
-                + f'"host_name": "{args.pushgateway_hostname}", "generated_request_id": "{unique_id}", "port": "{args.pushgateway_port}"'
-            )
-
-        push_metrics(
-            METRICS_REGISTRY,
+    for message in messages:
+        handle_message(
+            message,
+            dynamodb_client,
+            sqs_client,
+            sns_client,
+            args.dynamo_db_export_status_table_name,
+            args.monitoring_sns_topic_arn,
+            args.export_state_sqs_queue_url,
             args.pushgateway_hostname,
             args.pushgateway_port,
-            unique_id,
         )
 
 

--- a/tests/test_status_checker.py
+++ b/tests/test_status_checker.py
@@ -258,6 +258,7 @@ class TestReplayer(unittest.TestCase):
             PUSHGATEWAY_PORT,
             METRICS_JOB_NAME,
             CORRELATION_ID_1,
+            mock.ANY,
         )
 
     @mock.patch("status_checker_lambda.status_checker.delete_metrics")
@@ -2583,6 +2584,7 @@ class TestReplayer(unittest.TestCase):
             PUSHGATEWAY_PORT,
             METRICS_JOB_NAME,
             CORRELATION_ID_1,
+            1,
         )
 
         expected_url = f"{PUSHGATEWAY_HOSTNAME}:{PUSHGATEWAY_PORT}"

--- a/tests/test_status_checker.py
+++ b/tests/test_status_checker.py
@@ -277,7 +277,7 @@ class TestReplayer(unittest.TestCase):
         dynamodb_client_mock = mock.MagicMock()
         sqs_client_mock = mock.MagicMock()
         sns_client_mock = mock.MagicMock()
-        
+
         process_message_mock.side_effect = Exception("Test")
 
         process_message_mock.return_value = False
@@ -335,9 +335,9 @@ class TestReplayer(unittest.TestCase):
     @mock.patch("status_checker_lambda.status_checker.check_for_mandatory_keys")
     @mock.patch("status_checker_lambda.status_checker.logger")
     def test_handle_message_stops_when_missing_mandatory_keys(
-        self, 
-        mock_logger, 
-        check_for_mandatory_keys_mock, 
+        self,
+        mock_logger,
+        check_for_mandatory_keys_mock,
         process_message_mock,
         push_metrics_mock,
         delete_metrics_mock,

--- a/tests/test_status_checker.py
+++ b/tests/test_status_checker.py
@@ -39,8 +39,7 @@ TEST_FILE_NAME = "test_file"
 SLACK_USERNAME = "Snapshot Sender"
 PUSHGATEWAY_HOSTNAME = "test-host"
 PUSHGATEWAY_PORT = 9090
-REQUEST_ID_FIELD_NAME = "awsRequestId"
-REQUEST_ID = "awsRequestTestId"
+METRICS_JOB_NAME = "snapshot_sender_status_checker"
 
 args = argparse.Namespace()
 args.dynamo_db_export_status_table_name = DDB_TABLE_NAME
@@ -52,7 +51,6 @@ args.log_level = "INFO"
 
 
 class TestReplayer(unittest.TestCase):
-    @mock.patch("status_checker_lambda.status_checker.push_metrics")
     @mock.patch("status_checker_lambda.status_checker.handle_message")
     @mock.patch("status_checker_lambda.status_checker.extract_messages")
     @mock.patch("status_checker_lambda.status_checker.setup_logging")
@@ -67,89 +65,6 @@ class TestReplayer(unittest.TestCase):
         setup_logging_mock,
         extract_messages_mock,
         handle_message_mock,
-        push_metrics_mock,
-    ):
-        dynamodb_client_mock = mock.MagicMock()
-        sqs_client_mock = mock.MagicMock()
-        sns_client_mock = mock.MagicMock()
-        get_client_mock_return_values = {
-            "dynamodb": dynamodb_client_mock,
-            "sqs": sqs_client_mock,
-            "sns": sns_client_mock,
-        }
-        get_client_mock.side_effect = get_client_mock_return_values.get
-
-        get_parameters_mock.return_value = args
-
-        extract_messages_mock.return_value = [
-            {"test1": "test_value1"},
-            {"test2": "test_value2"},
-        ]
-
-        event = {
-            COLLECTION_NAME_FIELD_NAME: COLLECTION_1,
-            CORRELATION_ID_FIELD_NAME: CORRELATION_ID_1,
-            SNAPSHOT_TYPE_FIELD_NAME: SNAPSHOT_TYPE,
-            EXPORT_DATE_FIELD_NAME: EXPORT_DATE,
-            REQUEST_ID_FIELD_NAME: REQUEST_ID,
-        }
-
-        status_checker.handler(event, None)
-
-        get_client_mock.assert_any_call("dynamodb")
-        get_client_mock.assert_any_call("sqs")
-        get_client_mock.assert_any_call("sns")
-
-        get_parameters_mock.assert_called_once()
-        setup_logging_mock.assert_called_once()
-
-        extract_messages_mock.assert_called_once_with(event)
-
-        self.assertEqual(handle_message_mock.call_count, 2)
-        handle_message_mock.assert_any_call(
-            {"test1": "test_value1"},
-            dynamodb_client_mock,
-            sqs_client_mock,
-            sns_client_mock,
-            DDB_TABLE_NAME,
-            SNS_TOPIC_ARN,
-            SQS_QUEUE_URL,
-        )
-        handle_message_mock.assert_any_call(
-            {"test2": "test_value2"},
-            dynamodb_client_mock,
-            sqs_client_mock,
-            sns_client_mock,
-            DDB_TABLE_NAME,
-            SNS_TOPIC_ARN,
-            SQS_QUEUE_URL,
-        )
-
-        push_metrics_mock.assert_called_once_with(
-            mock.ANY,
-            PUSHGATEWAY_HOSTNAME,
-            PUSHGATEWAY_PORT,
-            REQUEST_ID,
-        )
-
-
-class TestReplayer(unittest.TestCase):
-    @mock.patch("status_checker_lambda.status_checker.push_metrics")
-    @mock.patch("status_checker_lambda.status_checker.handle_message")
-    @mock.patch("status_checker_lambda.status_checker.extract_messages")
-    @mock.patch("status_checker_lambda.status_checker.setup_logging")
-    @mock.patch("status_checker_lambda.status_checker.get_parameters")
-    @mock.patch("status_checker_lambda.status_checker.get_client")
-    @mock.patch("status_checker_lambda.status_checker.logger")
-    def test_handler_gets_clients_and_processes_all_messages_with_no_request_id(
-        self,
-        mock_logger,
-        get_client_mock,
-        get_parameters_mock,
-        setup_logging_mock,
-        extract_messages_mock,
-        handle_message_mock,
-        push_metrics_mock,
     ):
         dynamodb_client_mock = mock.MagicMock()
         sqs_client_mock = mock.MagicMock()
@@ -195,6 +110,8 @@ class TestReplayer(unittest.TestCase):
             DDB_TABLE_NAME,
             SNS_TOPIC_ARN,
             SQS_QUEUE_URL,
+            PUSHGATEWAY_HOSTNAME,
+            PUSHGATEWAY_PORT,
         )
         handle_message_mock.assert_any_call(
             {"test2": "test_value2"},
@@ -204,61 +121,12 @@ class TestReplayer(unittest.TestCase):
             DDB_TABLE_NAME,
             SNS_TOPIC_ARN,
             SQS_QUEUE_URL,
-        )
-
-        push_metrics_mock.assert_called_once_with(
-            mock.ANY,
             PUSHGATEWAY_HOSTNAME,
             PUSHGATEWAY_PORT,
-            mock.ANY,
         )
 
-
-class TestReplayer(unittest.TestCase):
+    @mock.patch("status_checker_lambda.status_checker.delete_metrics")
     @mock.patch("status_checker_lambda.status_checker.push_metrics")
-    @mock.patch("status_checker_lambda.status_checker.handle_message")
-    @mock.patch("status_checker_lambda.status_checker.extract_messages")
-    @mock.patch("status_checker_lambda.status_checker.setup_logging")
-    @mock.patch("status_checker_lambda.status_checker.get_parameters")
-    @mock.patch("status_checker_lambda.status_checker.get_client")
-    @mock.patch("status_checker_lambda.status_checker.logger")
-    def test_handler_pushes_metrics_even_when_error(
-        self,
-        mock_logger,
-        get_client_mock,
-        get_parameters_mock,
-        setup_logging_mock,
-        extract_messages_mock,
-        handle_message_mock,
-        push_metrics_mock,
-    ):
-        get_client_mock.side_effect = Exception("Test")
-        get_parameters_mock.return_value = args
-
-        event = {
-            COLLECTION_NAME_FIELD_NAME: COLLECTION_1,
-            CORRELATION_ID_FIELD_NAME: CORRELATION_ID_1,
-            SNAPSHOT_TYPE_FIELD_NAME: SNAPSHOT_TYPE,
-            EXPORT_DATE_FIELD_NAME: EXPORT_DATE,
-        }
-
-        with self.assertRaises(Exception):
-            status_checker.handler(event, None)
-
-        get_parameters_mock.assert_called_once()
-        setup_logging_mock.assert_called_once()
-        get_client_mock.assert_called_once()
-
-        push_metrics_mock.assert_called_once_with(
-            mock.ANY,
-            PUSHGATEWAY_HOSTNAME,
-            PUSHGATEWAY_PORT,
-            mock.ANY,
-        )
-
-        extract_messages_mock.assert_not_called()
-        handle_message_mock.assert_not_called()
-
     @mock.patch("status_checker_lambda.status_checker.process_message")
     @mock.patch("status_checker_lambda.status_checker.check_for_mandatory_keys")
     @mock.patch("status_checker_lambda.status_checker.logger")
@@ -267,11 +135,14 @@ class TestReplayer(unittest.TestCase):
         mock_logger,
         check_for_mandatory_keys_mock,
         process_message_mock,
+        push_metrics_mock,
+        delete_metrics_mock,
     ):
         dynamodb_client_mock = mock.MagicMock()
         sqs_client_mock = mock.MagicMock()
         sns_client_mock = mock.MagicMock()
 
+        process_message_mock.return_value = False
         check_for_mandatory_keys_mock.return_value = True
 
         message = {
@@ -290,6 +161,8 @@ class TestReplayer(unittest.TestCase):
             DDB_TABLE_NAME,
             SNS_TOPIC_ARN,
             SQS_QUEUE_URL,
+            PUSHGATEWAY_HOSTNAME,
+            PUSHGATEWAY_PORT,
         )
 
         process_message_mock.assert_called_once_with(
@@ -307,16 +180,172 @@ class TestReplayer(unittest.TestCase):
             TEST_FILE_NAME,
         )
 
+        push_metrics_mock.assert_called_once_with(
+            mock.ANY,
+            PUSHGATEWAY_HOSTNAME,
+            PUSHGATEWAY_PORT,
+            METRICS_JOB_NAME,
+            CORRELATION_ID_1,
+        )
+
+        delete_metrics_mock.assert_not_called()
+
+    @mock.patch("status_checker_lambda.status_checker.delete_metrics")
+    @mock.patch("status_checker_lambda.status_checker.push_metrics")
     @mock.patch("status_checker_lambda.status_checker.process_message")
     @mock.patch("status_checker_lambda.status_checker.check_for_mandatory_keys")
     @mock.patch("status_checker_lambda.status_checker.logger")
-    def test_handle_message_stops_when_missing_mandatory_keys(
-        self, mock_logger, check_for_mandatory_keys_mock, process_message_mock
+    def test_handle_message_deletes_metrics_when_all_collections_successful(
+        self,
+        mock_logger,
+        check_for_mandatory_keys_mock,
+        process_message_mock,
+        push_metrics_mock,
+        delete_metrics_mock,
     ):
         dynamodb_client_mock = mock.MagicMock()
         sqs_client_mock = mock.MagicMock()
         sns_client_mock = mock.MagicMock()
 
+        process_message_mock.return_value = True
+        check_for_mandatory_keys_mock.return_value = True
+
+        message = {
+            COLLECTION_NAME_FIELD_NAME: COLLECTION_1,
+            CORRELATION_ID_FIELD_NAME: CORRELATION_ID_1,
+            SNAPSHOT_TYPE_FIELD_NAME: SNAPSHOT_TYPE,
+            EXPORT_DATE_FIELD_NAME: EXPORT_DATE,
+            FILE_NAME_FIELD_NAME: TEST_FILE_NAME,
+        }
+
+        status_checker.handle_message(
+            message,
+            dynamodb_client_mock,
+            sqs_client_mock,
+            sns_client_mock,
+            DDB_TABLE_NAME,
+            SNS_TOPIC_ARN,
+            SQS_QUEUE_URL,
+            PUSHGATEWAY_HOSTNAME,
+            PUSHGATEWAY_PORT,
+        )
+
+        process_message_mock.assert_called_once_with(
+            message,
+            dynamodb_client_mock,
+            sqs_client_mock,
+            sns_client_mock,
+            DDB_TABLE_NAME,
+            SNS_TOPIC_ARN,
+            SQS_QUEUE_URL,
+            CORRELATION_ID_1,
+            COLLECTION_1,
+            SNAPSHOT_TYPE,
+            EXPORT_DATE,
+            TEST_FILE_NAME,
+        )
+
+        push_metrics_mock.assert_called_once_with(
+            mock.ANY,
+            PUSHGATEWAY_HOSTNAME,
+            PUSHGATEWAY_PORT,
+            METRICS_JOB_NAME,
+            CORRELATION_ID_1,
+        )
+
+        delete_metrics_mock.assert_called_once_with(
+            PUSHGATEWAY_HOSTNAME,
+            PUSHGATEWAY_PORT,
+            METRICS_JOB_NAME,
+            CORRELATION_ID_1,
+        )
+
+    @mock.patch("status_checker_lambda.status_checker.delete_metrics")
+    @mock.patch("status_checker_lambda.status_checker.push_metrics")
+    @mock.patch("status_checker_lambda.status_checker.process_message")
+    @mock.patch("status_checker_lambda.status_checker.check_for_mandatory_keys")
+    @mock.patch("status_checker_lambda.status_checker.logger")
+    def test_handle_message_pushes_metrics_even_when_error(
+        self,
+        mock_logger,
+        check_for_mandatory_keys_mock,
+        process_message_mock,
+        push_metrics_mock,
+        delete_metrics_mock,
+    ):
+        dynamodb_client_mock = mock.MagicMock()
+        sqs_client_mock = mock.MagicMock()
+        sns_client_mock = mock.MagicMock()
+        
+        process_message_mock.side_effect = Exception("Test")
+
+        process_message_mock.return_value = False
+        check_for_mandatory_keys_mock.return_value = True
+
+        message = {
+            COLLECTION_NAME_FIELD_NAME: COLLECTION_1,
+            CORRELATION_ID_FIELD_NAME: CORRELATION_ID_1,
+            SNAPSHOT_TYPE_FIELD_NAME: SNAPSHOT_TYPE,
+            EXPORT_DATE_FIELD_NAME: EXPORT_DATE,
+            FILE_NAME_FIELD_NAME: TEST_FILE_NAME,
+        }
+
+        with self.assertRaises(Exception):
+            status_checker.handle_message(
+                message,
+                dynamodb_client_mock,
+                sqs_client_mock,
+                sns_client_mock,
+                DDB_TABLE_NAME,
+                SNS_TOPIC_ARN,
+                SQS_QUEUE_URL,
+                PUSHGATEWAY_HOSTNAME,
+                PUSHGATEWAY_PORT,
+            )
+
+        process_message_mock.assert_called_once_with(
+            message,
+            dynamodb_client_mock,
+            sqs_client_mock,
+            sns_client_mock,
+            DDB_TABLE_NAME,
+            SNS_TOPIC_ARN,
+            SQS_QUEUE_URL,
+            CORRELATION_ID_1,
+            COLLECTION_1,
+            SNAPSHOT_TYPE,
+            EXPORT_DATE,
+            TEST_FILE_NAME,
+        )
+
+        push_metrics_mock.assert_called_once_with(
+            mock.ANY,
+            PUSHGATEWAY_HOSTNAME,
+            PUSHGATEWAY_PORT,
+            METRICS_JOB_NAME,
+            CORRELATION_ID_1,
+        )
+
+        delete_metrics_mock.assert_not_called()
+
+    @mock.patch("status_checker_lambda.status_checker.delete_metrics")
+    @mock.patch("status_checker_lambda.status_checker.push_metrics")
+    @mock.patch("status_checker_lambda.status_checker.process_message")
+    @mock.patch("status_checker_lambda.status_checker.check_for_mandatory_keys")
+    @mock.patch("status_checker_lambda.status_checker.logger")
+    def test_handle_message_stops_when_missing_mandatory_keys(
+        self, 
+        mock_logger, 
+        check_for_mandatory_keys_mock, 
+        process_message_mock,
+        push_metrics_mock,
+        delete_metrics_mock,
+    ):
+        dynamodb_client_mock = mock.MagicMock()
+        sqs_client_mock = mock.MagicMock()
+        sns_client_mock = mock.MagicMock()
+
+        process_message_mock.return_value = False
         check_for_mandatory_keys_mock.return_value = False
 
         message = {
@@ -334,9 +363,13 @@ class TestReplayer(unittest.TestCase):
             DDB_TABLE_NAME,
             SNS_TOPIC_ARN,
             SQS_QUEUE_URL,
+            PUSHGATEWAY_HOSTNAME,
+            PUSHGATEWAY_PORT,
         )
 
         process_message_mock.assert_not_called()
+        push_metrics_mock.assert_not_called()
+        delete_metrics_mock.assert_not_called()
 
     @mock.patch("status_checker_lambda.status_checker.process_normal_file_message")
     @mock.patch("status_checker_lambda.status_checker.process_success_file_message")
@@ -353,7 +386,7 @@ class TestReplayer(unittest.TestCase):
 
         message = {}
 
-        status_checker.process_message(
+        result = status_checker.process_message(
             message,
             dynamodb_client_mock,
             sqs_client_mock,
@@ -385,6 +418,8 @@ class TestReplayer(unittest.TestCase):
         )
 
         process_success_file_message_mock.assert_not_called()
+
+        self.assertFalse(result)
 
     @mock.patch("status_checker_lambda.status_checker.process_normal_file_message")
     @mock.patch("status_checker_lambda.status_checker.process_success_file_message")
@@ -403,7 +438,7 @@ class TestReplayer(unittest.TestCase):
             IS_SUCCESS_FILE_FIELD_NAME: None,
         }
 
-        status_checker.process_message(
+        result = status_checker.process_message(
             message,
             dynamodb_client_mock,
             sqs_client_mock,
@@ -435,6 +470,8 @@ class TestReplayer(unittest.TestCase):
         )
 
         process_success_file_message_mock.assert_not_called()
+
+        self.assertFalse(result)
 
     @mock.patch("status_checker_lambda.status_checker.process_normal_file_message")
     @mock.patch("status_checker_lambda.status_checker.process_success_file_message")
@@ -453,7 +490,7 @@ class TestReplayer(unittest.TestCase):
             IS_SUCCESS_FILE_FIELD_NAME: "",
         }
 
-        status_checker.process_message(
+        result = status_checker.process_message(
             message,
             dynamodb_client_mock,
             sqs_client_mock,
@@ -485,6 +522,8 @@ class TestReplayer(unittest.TestCase):
         )
 
         process_success_file_message_mock.assert_not_called()
+
+        self.assertFalse(result)
 
     @mock.patch("status_checker_lambda.status_checker.process_normal_file_message")
     @mock.patch("status_checker_lambda.status_checker.process_success_file_message")
@@ -503,7 +542,7 @@ class TestReplayer(unittest.TestCase):
             IS_SUCCESS_FILE_FIELD_NAME: "false",
         }
 
-        status_checker.process_message(
+        result = status_checker.process_message(
             message,
             dynamodb_client_mock,
             sqs_client_mock,
@@ -536,6 +575,8 @@ class TestReplayer(unittest.TestCase):
 
         process_success_file_message_mock.assert_not_called()
 
+        self.assertFalse(result)
+
     @mock.patch("status_checker_lambda.status_checker.process_normal_file_message")
     @mock.patch("status_checker_lambda.status_checker.process_success_file_message")
     @mock.patch("status_checker_lambda.status_checker.logger")
@@ -549,11 +590,13 @@ class TestReplayer(unittest.TestCase):
         sqs_client_mock = mock.MagicMock()
         sns_client_mock = mock.MagicMock()
 
+        process_success_file_message_mock.return_value = False
+
         message = {
             IS_SUCCESS_FILE_FIELD_NAME: "true",
         }
 
-        status_checker.process_message(
+        result = status_checker.process_message(
             message,
             dynamodb_client_mock,
             sqs_client_mock,
@@ -581,6 +624,8 @@ class TestReplayer(unittest.TestCase):
         )
 
         process_normal_file_message_mock.assert_not_called()
+
+        self.assertFalse(result)
 
     @mock.patch("status_checker_lambda.status_checker.process_normal_file_message")
     @mock.patch("status_checker_lambda.status_checker.process_success_file_message")
@@ -595,11 +640,13 @@ class TestReplayer(unittest.TestCase):
         sqs_client_mock = mock.MagicMock()
         sns_client_mock = mock.MagicMock()
 
+        process_success_file_message_mock.return_value = True
+
         message = {
             IS_SUCCESS_FILE_FIELD_NAME: "TRUE",
         }
 
-        status_checker.process_message(
+        result = status_checker.process_message(
             message,
             dynamodb_client_mock,
             sqs_client_mock,
@@ -627,6 +674,8 @@ class TestReplayer(unittest.TestCase):
         )
 
         process_normal_file_message_mock.assert_not_called()
+
+        self.assertTrue(result)
 
     @mock.patch("status_checker_lambda.status_checker.send_sns_message")
     @mock.patch(
@@ -1257,7 +1306,7 @@ class TestReplayer(unittest.TestCase):
         }
         generate_monitoring_message_payload_mock.return_value = expected_payload_sns
 
-        status_checker.process_success_file_message(
+        result = status_checker.process_success_file_message(
             DDB_TABLE_NAME,
             dynamodb_client_mock,
             sns_client_mock,
@@ -1325,6 +1374,8 @@ class TestReplayer(unittest.TestCase):
             TEST_FILE_NAME,
         )
 
+        self.assertTrue(result)
+
     @mock.patch("status_checker_lambda.status_checker.send_sns_message")
     @mock.patch(
         "status_checker_lambda.status_checker.generate_monitoring_message_payload"
@@ -1372,7 +1423,7 @@ class TestReplayer(unittest.TestCase):
 
         check_completion_status_mock.return_value = False
 
-        status_checker.process_success_file_message(
+        result = status_checker.process_success_file_message(
             DDB_TABLE_NAME,
             dynamodb_client_mock,
             sns_client_mock,
@@ -1428,6 +1479,8 @@ class TestReplayer(unittest.TestCase):
         generate_monitoring_message_payload_mock.assert_not_called()
         send_sns_message_mock.assert_not_called()
 
+        self.assertFalse(result)
+
     @mock.patch("status_checker_lambda.status_checker.send_sns_message")
     @mock.patch(
         "status_checker_lambda.status_checker.generate_monitoring_message_payload"
@@ -1461,7 +1514,7 @@ class TestReplayer(unittest.TestCase):
         get_current_collection_mock.return_value = single_collection_result
         is_collection_success_mock.return_value = False
 
-        status_checker.process_success_file_message(
+        result = status_checker.process_success_file_message(
             DDB_TABLE_NAME,
             dynamodb_client_mock,
             sns_client_mock,
@@ -1495,6 +1548,8 @@ class TestReplayer(unittest.TestCase):
         check_completion_status_mock.assert_not_called()
         generate_monitoring_message_payload_mock.assert_not_called()
         send_sns_message_mock.assert_not_called()
+
+        self.assertFalse(result)
 
     @mock.patch("status_checker_lambda.status_checker.logger")
     def test_sns_payload_generates_valid_payload(self, mock_logger):
@@ -1834,18 +1889,14 @@ class TestReplayer(unittest.TestCase):
             )
         )
 
-    @mock.patch("status_checker_lambda.status_checker.add_label_values_to_metric")
+    @mock.patch("status_checker_lambda.status_checker.increment_counter")
     @mock.patch("status_checker_lambda.status_checker.logger")
     def test_is_collection_received_returns_true_for_sent_status(
         self,
         mock_logger,
-        add_label_values_to_metric_mock,
+        increment_counter_mock,
     ):
         counter = mock.MagicMock()
-        counter_with_labels = mock.MagicMock()
-        counter_with_labels.inc = mock.MagicMock()
-
-        add_label_values_to_metric_mock.return_value = counter_with_labels
 
         event = {
             "CollectionStatus": {"S": SENT_STATUS},
@@ -1864,31 +1915,24 @@ class TestReplayer(unittest.TestCase):
             counter,
         )
 
-        add_label_values_to_metric_mock.assert_called_once_with(
+        increment_counter_mock.assert_called_once_with(
             counter,
             CORRELATION_ID_1,
             COLLECTION_1,
             EXPORT_DATE,
             SNAPSHOT_TYPE,
-            TEST_FILE_NAME,
         )
-
-        counter_with_labels.inc.assert_called_once()
 
         self.assertTrue(actual)
 
-    @mock.patch("status_checker_lambda.status_checker.add_label_values_to_metric")
+    @mock.patch("status_checker_lambda.status_checker.increment_counter")
     @mock.patch("status_checker_lambda.status_checker.logger")
     def test_is_collection_received_returns_true_for_exported_status(
         self,
         mock_logger,
-        add_label_values_to_metric_mock,
+        increment_counter_mock,
     ):
         counter = mock.MagicMock()
-        counter_with_labels = mock.MagicMock()
-        counter_with_labels.inc = mock.MagicMock()
-
-        add_label_values_to_metric_mock.return_value = counter_with_labels
 
         event = {
             "CollectionStatus": {"S": EXPORTED_STATUS},
@@ -1907,31 +1951,25 @@ class TestReplayer(unittest.TestCase):
             counter,
         )
 
-        add_label_values_to_metric_mock.assert_called_once_with(
+        increment_counter_mock.assert_called_once_with(
             counter,
             CORRELATION_ID_1,
             COLLECTION_1,
             EXPORT_DATE,
             SNAPSHOT_TYPE,
-            TEST_FILE_NAME,
         )
-
-        counter_with_labels.inc.assert_called_once()
 
         self.assertTrue(actual)
 
-    @mock.patch("status_checker_lambda.status_checker.add_label_values_to_metric")
+    @mock.patch("status_checker_lambda.status_checker.increment_counter")
     @mock.patch("status_checker_lambda.status_checker.logger")
     def test_is_collection_received_returns_false_when_more_files_exported(
         self,
         mock_logger,
-        add_label_values_to_metric_mock,
+        increment_counter_mock,
     ):
         counter = mock.MagicMock()
-        counter_with_labels = mock.MagicMock()
-        counter_with_labels.inc = mock.MagicMock()
-
-        add_label_values_to_metric_mock.return_value = counter_with_labels
+        counter.inc = mock.MagicMock()
 
         event = {
             "CollectionStatus": {"S": SENT_STATUS},
@@ -1950,23 +1988,19 @@ class TestReplayer(unittest.TestCase):
             counter,
         )
 
-        add_label_values_to_metric_mock.assert_not_called()
-        counter_with_labels.inc.assert_not_called()
+        increment_counter_mock.assert_not_called()
+        counter.inc.assert_not_called()
 
         self.assertFalse(actual)
 
-    @mock.patch("status_checker_lambda.status_checker.add_label_values_to_metric")
+    @mock.patch("status_checker_lambda.status_checker.increment_counter")
     @mock.patch("status_checker_lambda.status_checker.logger")
     def test_is_collection_received_returns_true_when_more_files_sent(
         self,
         mock_logger,
-        add_label_values_to_metric_mock,
+        increment_counter_mock,
     ):
         counter = mock.MagicMock()
-        counter_with_labels = mock.MagicMock()
-        counter_with_labels.inc = mock.MagicMock()
-
-        add_label_values_to_metric_mock.return_value = counter_with_labels
 
         event = {
             "CollectionStatus": {"S": EXPORTED_STATUS},
@@ -1985,31 +2019,25 @@ class TestReplayer(unittest.TestCase):
             counter,
         )
 
-        add_label_values_to_metric_mock.assert_called_once_with(
+        increment_counter_mock.assert_called_once_with(
             counter,
             CORRELATION_ID_1,
             COLLECTION_1,
             EXPORT_DATE,
             SNAPSHOT_TYPE,
-            TEST_FILE_NAME,
         )
-
-        counter_with_labels.inc.assert_called_once()
 
         self.assertTrue(actual)
 
-    @mock.patch("status_checker_lambda.status_checker.add_label_values_to_metric")
+    @mock.patch("status_checker_lambda.status_checker.increment_counter")
     @mock.patch("status_checker_lambda.status_checker.logger")
     def test_is_collection_received_returns_false_when_more_files_received(
         self,
         mock_logger,
-        add_label_values_to_metric_mock,
+        increment_counter_mock,
     ):
         counter = mock.MagicMock()
-        counter_with_labels = mock.MagicMock()
-        counter_with_labels.inc = mock.MagicMock()
-
-        add_label_values_to_metric_mock.return_value = counter_with_labels
+        counter.inc = mock.MagicMock()
 
         event = {
             "CollectionStatus": {"S": SENT_STATUS},
@@ -2028,23 +2056,20 @@ class TestReplayer(unittest.TestCase):
             counter,
         )
 
-        add_label_values_to_metric_mock.assert_not_called()
-        counter_with_labels.inc.assert_not_called()
+        increment_counter_mock.assert_not_called()
+        counter.inc.assert_not_called()
 
         self.assertFalse(actual)
 
-    @mock.patch("status_checker_lambda.status_checker.add_label_values_to_metric")
+    @mock.patch("status_checker_lambda.status_checker.increment_counter")
     @mock.patch("status_checker_lambda.status_checker.logger")
     def test_is_collection_received_returns_false_when_more_files_exported_and_sent(
         self,
         mock_logger,
-        add_label_values_to_metric_mock,
+        increment_counter_mock,
     ):
         counter = mock.MagicMock()
-        counter_with_labels = mock.MagicMock()
-        counter_with_labels.inc = mock.MagicMock()
-
-        add_label_values_to_metric_mock.return_value = counter_with_labels
+        counter.inc = mock.MagicMock()
 
         event = {
             "CollectionStatus": {"S": EXPORTED_STATUS},
@@ -2063,23 +2088,20 @@ class TestReplayer(unittest.TestCase):
             counter,
         )
 
-        add_label_values_to_metric_mock.assert_not_called()
-        counter_with_labels.inc.assert_not_called()
+        increment_counter_mock.assert_not_called()
+        counter.inc.assert_not_called()
 
         self.assertFalse(actual)
 
-    @mock.patch("status_checker_lambda.status_checker.add_label_values_to_metric")
+    @mock.patch("status_checker_lambda.status_checker.increment_counter")
     @mock.patch("status_checker_lambda.status_checker.logger")
     def test_is_collection_received_returns_false_when_collection_status_not_sent_or_exported(
         self,
         mock_logger,
-        add_label_values_to_metric_mock,
+        increment_counter_mock,
     ):
         counter = mock.MagicMock()
-        counter_with_labels = mock.MagicMock()
-        counter_with_labels.inc = mock.MagicMock()
-
-        add_label_values_to_metric_mock.return_value = counter_with_labels
+        counter.inc = mock.MagicMock()
 
         event = {
             "CollectionStatus": {"S": EXPORTING_STATUS},
@@ -2098,23 +2120,19 @@ class TestReplayer(unittest.TestCase):
             counter,
         )
 
-        add_label_values_to_metric_mock.assert_not_called()
-        counter_with_labels.inc.assert_not_called()
+        increment_counter_mock.assert_not_called()
+        counter.inc.assert_not_called()
 
         self.assertFalse(actual)
 
-    @mock.patch("status_checker_lambda.status_checker.add_label_values_to_metric")
+    @mock.patch("status_checker_lambda.status_checker.increment_counter")
     @mock.patch("status_checker_lambda.status_checker.logger")
     def test_is_collection_success_returns_true_for_received_collection(
         self,
         mock_logger,
-        add_label_values_to_metric_mock,
+        increment_counter_mock,
     ):
         counter = mock.MagicMock()
-        counter_with_labels = mock.MagicMock()
-        counter_with_labels.inc = mock.MagicMock()
-
-        add_label_values_to_metric_mock.return_value = counter_with_labels
 
         event = {
             "CollectionStatus": {"S": RECEIVED_STATUS},
@@ -2130,31 +2148,24 @@ class TestReplayer(unittest.TestCase):
             counter,
         )
 
-        add_label_values_to_metric_mock.assert_called_once_with(
+        increment_counter_mock.assert_called_once_with(
             counter,
             CORRELATION_ID_1,
             COLLECTION_1,
             EXPORT_DATE,
             SNAPSHOT_TYPE,
-            TEST_FILE_NAME,
         )
-
-        counter_with_labels.inc.assert_called_once()
 
         self.assertTrue(actual)
 
-    @mock.patch("status_checker_lambda.status_checker.add_label_values_to_metric")
+    @mock.patch("status_checker_lambda.status_checker.increment_counter")
     @mock.patch("status_checker_lambda.status_checker.logger")
     def test_is_collection_success_returns_true_for_sent_collection(
         self,
         mock_logger,
-        add_label_values_to_metric_mock,
+        increment_counter_mock,
     ):
         counter = mock.MagicMock()
-        counter_with_labels = mock.MagicMock()
-        counter_with_labels.inc = mock.MagicMock()
-
-        add_label_values_to_metric_mock.return_value = counter_with_labels
 
         event = {
             "CollectionStatus": {"S": SENT_STATUS},
@@ -2170,31 +2181,25 @@ class TestReplayer(unittest.TestCase):
             counter,
         )
 
-        add_label_values_to_metric_mock.assert_called_once_with(
+        increment_counter_mock.assert_called_once_with(
             counter,
             CORRELATION_ID_1,
             COLLECTION_1,
             EXPORT_DATE,
             SNAPSHOT_TYPE,
-            TEST_FILE_NAME,
         )
-
-        counter_with_labels.inc.assert_called_once()
 
         self.assertTrue(actual)
 
-    @mock.patch("status_checker_lambda.status_checker.add_label_values_to_metric")
+    @mock.patch("status_checker_lambda.status_checker.increment_counter")
     @mock.patch("status_checker_lambda.status_checker.logger")
     def test_is_collection_success_returns_false(
         self,
         mock_logger,
-        add_label_values_to_metric_mock,
+        increment_counter_mock,
     ):
         counter = mock.MagicMock()
-        counter_with_labels = mock.MagicMock()
-        counter_with_labels.inc = mock.MagicMock()
-
-        add_label_values_to_metric_mock.return_value = counter_with_labels
+        counter.inc = mock.MagicMock()
 
         event = {
             "CollectionStatus": {"S": EXPORTED_STATUS},
@@ -2210,8 +2215,8 @@ class TestReplayer(unittest.TestCase):
             counter,
         )
 
-        add_label_values_to_metric_mock.assert_not_called()
-        counter_with_labels.inc.assert_not_called()
+        increment_counter_mock.assert_not_called()
+        counter.inc.assert_not_called()
 
         self.assertFalse(actual)
 
@@ -2518,28 +2523,26 @@ class TestReplayer(unittest.TestCase):
         self.assertEqual(expected, actual)
 
     @mock.patch("status_checker_lambda.status_checker.logger")
-    def test_add_label_values_to_metric_adds_correct_labels(
+    def test_increment_counter_mock_adds_correct_labels(
         self,
         mock_logger,
     ):
-        metric = mock.MagicMock()
-        metric.labels = mock.MagicMock()
+        counter = mock.MagicMock()
+        counter.labels = mock.MagicMock()
 
-        status_checker.add_label_values_to_metric(
-            metric,
+        status_checker.increment_counter(
+            counter,
             CORRELATION_ID_1,
             COLLECTION_1,
             EXPORT_DATE,
             SNAPSHOT_TYPE,
-            TEST_FILE_NAME,
         )
 
-        metric.labels.assert_called_once_with(
+        counter.labels.assert_called_once_with(
             correlation_id=CORRELATION_ID_1,
             collection_name=COLLECTION_1,
             export_date=EXPORT_DATE,
             snapshot_type=SNAPSHOT_TYPE,
-            file_name=TEST_FILE_NAME,
         )
 
     @mock.patch("status_checker_lambda.status_checker.prometheus_client")
@@ -2555,13 +2558,39 @@ class TestReplayer(unittest.TestCase):
             registry,
             PUSHGATEWAY_HOSTNAME,
             PUSHGATEWAY_PORT,
+            METRICS_JOB_NAME,
             CORRELATION_ID_1,
         )
 
-        prometheus_client_mock.push_to_gateway.assert_called_once_with(
-            f"{PUSHGATEWAY_HOSTNAME}:{PUSHGATEWAY_PORT}",
-            job=CORRELATION_ID_1,
+        expected_url = f"{PUSHGATEWAY_HOSTNAME}:{PUSHGATEWAY_PORT}"
+
+        prometheus_client_mock.pushadd_to_gateway.assert_called_once_with(
+            gateway=expected_url,
+            job=METRICS_JOB_NAME,
+            grouping_key=CORRELATION_ID_1,
             registry=registry,
+        )
+
+    @mock.patch("status_checker_lambda.status_checker.prometheus_client")
+    @mock.patch("status_checker_lambda.status_checker.logger")
+    def test_delete_metrics_sends_the_metrics(
+        self,
+        mock_logger,
+        prometheus_client_mock,
+    ):
+        status_checker.delete_metrics(
+            PUSHGATEWAY_HOSTNAME,
+            PUSHGATEWAY_PORT,
+            METRICS_JOB_NAME,
+            CORRELATION_ID_1,
+        )
+
+        expected_url = f"{PUSHGATEWAY_HOSTNAME}:{PUSHGATEWAY_PORT}"
+
+        prometheus_client_mock.delete_from_gateway.assert_called_once_with(
+            gateway=expected_url,
+            job=METRICS_JOB_NAME,
+            grouping_key=CORRELATION_ID_1,
         )
 
 


### PR DESCRIPTION
Rework the metrics so that they are grouped by correlation id, push added with every invocation and then deleted when a correlation id is successful